### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/arceuzvx/Financial-Wellness-Tracker/security/code-scanning/1](https://github.com/arceuzvx/Financial-Wellness-Tracker/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best practice is to set the most restrictive permissions at the workflow level (e.g., `contents: read`), and then, if a job or step requires more (such as `contents: write` for deployment), override it at the job level. In this case, since the deployment step uses the `JamesIves/github-pages-deploy-action`, which requires `contents: write`, the `build-and-deploy` job should have `contents: write` permission. The `permissions` block should be added as the first key under the job definition (i.e., after `runs-on`). No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
